### PR TITLE
image name optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
 - `tenant` SP tenant (mandatory)
 - `registry` the Azure container registry, minus the `.azurecr.io` part (mandatory)
 - `repository` remote repository (mandatory)
-- `image` the docker image name (mandatory)
+- `image` the docker image name (optional)
 - `folder` the context for the docker build (optional)
 - `dockerfile` the location of the Dockerfile relative to the context (optional)
 - `tag` the docker image tag, defaults to the short git SHA (optional)

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: true
   image:
     description: 'Docker image name'
-    required: true
+    required: false
   tag:
     description: 'Docker image tag, default to the commit SHA'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,12 @@ set -e
 
 INPUT_DOCKERFILE=${INPUT_DOCKERFILE:-Dockerfile}
 INPUT_TAG=${INPUT_TAG:-${GITHUB_SHA::8}}
+IMAGE_PART=""
 
-echo "Building Docker image ${INPUT_REPOSITORY}/${INPUT_IMAGE}:${INPUT_TAG} from ${GITHUB_REPOSITORY} on ${INPUT_BRANCH} and using context ${INPUT_FOLDER} ; and pushing it to ${INPUT_REGISTRY} Azure Container Registry"
+if [ "$INPUT_IMAGE" != "" ]; then
+        IMAGE_PART="/${INPUT_IMAGE}"
+fi
+
+echo "Building Docker image ${INPUT_REPOSITORY}${IMAGE_PART}:${INPUT_TAG} from ${GITHUB_REPOSITORY} on ${INPUT_BRANCH} and using context ${INPUT_FOLDER} ; and pushing it to ${INPUT_REGISTRY} Azure Container Registry"
 az login --service-principal -u ${INPUT_SERVICE_PRINCIPAL} -p ${INPUT_SERVICE_PRINCIPAL_PASSWORD} --tenant ${INPUT_TENANT}
-az acr build -r ${INPUT_REGISTRY} -f ${INPUT_DOCKERFILE} -t ${INPUT_REPOSITORY}/${INPUT_IMAGE}:${INPUT_TAG} https://github.com/${GITHUB_REPOSITORY}.git#${INPUT_BRANCH}:${INPUT_FOLDER}
+az acr build -r ${INPUT_REGISTRY} -f ${INPUT_DOCKERFILE} -t ${INPUT_REPOSITORY}${IMAGE_PART}:${INPUT_TAG} https://github.com/${GITHUB_REPOSITORY}.git#${INPUT_BRANCH}:${INPUT_FOLDER}


### PR DESCRIPTION
I propose a change to make image name optional. As I understand image name in docker is rather it's generated id, and image alias is like REGISTRY/REPOSITORY:TAG. 
Making image name paramter required ends in having repository name in ACR as REPOSITORY/IMAGE (action inputs). 
I am open for discussion regarding this suggestion and actual solution. 