### PR TITLE
Feature/build args

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,4 @@ jobs:
 - `folder` the context for the docker build (optional)
 - `dockerfile` the location of the Dockerfile relative to the context (optional)
 - `tag` the docker image tag, defaults to the short git SHA (optional)
+- `build_args` the docker build args in JSON format (`[{"MY_ARG": "this_is_a_test"}]`)

--- a/action.yml
+++ b/action.yml
@@ -1,40 +1,43 @@
-name: 'Azure Container Registry Build'
-author: 'Alessandro Vozza'
+name: "Azure Container Registry Build"
+author: "Alessandro Vozza"
 branding:
-  icon: 'code'
-  color: 'blue'
-description: 'Use ACR to build a container image'
+  icon: "code"
+  color: "blue"
+description: "Use ACR to build a container image"
 inputs:
   service_principal:
-    description: 'Service Principal with Contributor role on the ACR'
+    description: "Service Principal with Contributor role on the ACR"
     required: true
   service_principal_password:
-    description: 'Service Principal password'
+    description: "Service Principal password"
     required: true
   tenant:
-    description: 'Azure Container Registry tenant'
+    description: "Azure Container Registry tenant"
     required: true
   registry:
-    description: 'The name of the ACR, minus the .azurecr.io'
+    description: "The name of the ACR, minus the .azurecr.io"
     required: true
   repository:
-    description: 'Repository to use'
+    description: "Repository to use"
     required: true
   image:
-    description: 'Docker image name'
+    description: "Docker image name"
     required: false
   tag:
-    description: 'Docker image tag, default to the commit SHA'
+    description: "Docker image tag, default to the commit SHA"
     required: false
   branch:
-    description: 'Branch to build from, defaults to master'
+    description: "Branch to build from, defaults to master"
     required: false
   folder:
-    description: 'The folder in the Github repo that holds the source'
+    description: "The folder in the Github repo that holds the source"
     required: true
   dockerfile:
-    description: 'The location of the Dockerfile; defaults to ./Dockerfile'
+    description: "The location of the Dockerfile; defaults to ./Dockerfile"
+    required: false
+  build_args:
+    description: "JSON specifying key=value pairs as as Docker build arguments"
     required: false
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,8 +5,8 @@ INPUT_DOCKERFILE=${INPUT_DOCKERFILE:-Dockerfile}
 INPUT_TAG=${INPUT_TAG:-${GITHUB_SHA::8}}
 INPUT_BRANCH=${INPUT_BRANCH:-master}
 IMAGE_PART=""
-if [ -n "$BUILD_ARGS" ]; then
-        DOCKER_BUILD_ARGS=`echo -n ${BUILD_ARGS:-''} |jq -j '.[] | keys[] as $k | values[] as $v |  "--build-arg \($k)=\"\($v)\" "'`
+if [ -n "$INPUT_BUILD_ARGS" ]; then
+        BUILD_ARGS=`echo -n ${INPUT_BUILD_ARGS:-''} |jq -j '.[] | keys[] as $k | values[] as $v |  "--build-arg \($k)=\"\($v)\" "'`
 fi
 
 if [ "$INPUT_IMAGE" != "" ]; then
@@ -16,11 +16,11 @@ fi
 if [ -n "$INPUT_GIT_ACCESS_TOKEN" ]; then
         GIT_ACCESS_TOKEN_FLAG="${INPUT_GIT_ACCESS_TOKEN}@"
 fi
-echo ${DOCKER_BUILD_ARGS}
+
 echo "Building Docker image ${INPUT_REPOSITORY}${IMAGE_PART}:${INPUT_TAG} from ${GITHUB_REPOSITORY} on ${INPUT_BRANCH} and using context ${INPUT_FOLDER} ; and pushing it to ${INPUT_REGISTRY} Azure Container Registry"
 
 echo "Logging into azure.."
 az login --service-principal -u ${INPUT_SERVICE_PRINCIPAL} -p ${INPUT_SERVICE_PRINCIPAL_PASSWORD} --tenant ${INPUT_TENANT}
 
 echo "Sending build job to ACR.."
-az acr build -r ${INPUT_REGISTRY} ${DOCKER_BUILD_ARGS} -f ${INPUT_DOCKERFILE} -t ${INPUT_REPOSITORY}${IMAGE_PART}:${INPUT_TAG} https://${GIT_ACCESS_TOKEN_FLAG}github.com/${GITHUB_REPOSITORY}.git#${INPUT_BRANCH}:${INPUT_FOLDER}
+az acr build -r ${INPUT_REGISTRY} ${BUILD_ARGS} -f ${INPUT_DOCKERFILE} -t ${INPUT_REPOSITORY}${IMAGE_PART}:${INPUT_TAG} https://${GIT_ACCESS_TOKEN_FLAG}github.com/${GITHUB_REPOSITORY}.git#${INPUT_BRANCH}:${INPUT_FOLDER}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,11 +4,11 @@ set -e
 INPUT_DOCKERFILE=${INPUT_DOCKERFILE:-Dockerfile}
 INPUT_TAG=${INPUT_TAG:-${GITHUB_SHA::8}}
 IMAGE_PART=""
-
+DOCKER_BUILD_ARGS=`echo -n ${BUILD_ARGS:-''} |jq -j '.[] | keys[] as $k | values[] as $v |  "--build-arg \($k)=\($v) "'`
 if [ "$INPUT_IMAGE" != "" ]; then
         IMAGE_PART="/${INPUT_IMAGE}"
 fi
 
 echo "Building Docker image ${INPUT_REPOSITORY}${IMAGE_PART}:${INPUT_TAG} from ${GITHUB_REPOSITORY} on ${INPUT_BRANCH} and using context ${INPUT_FOLDER} ; and pushing it to ${INPUT_REGISTRY} Azure Container Registry"
 az login --service-principal -u ${INPUT_SERVICE_PRINCIPAL} -p ${INPUT_SERVICE_PRINCIPAL_PASSWORD} --tenant ${INPUT_TENANT}
-az acr build -r ${INPUT_REGISTRY} -f ${INPUT_DOCKERFILE} -t ${INPUT_REPOSITORY}${IMAGE_PART}:${INPUT_TAG} https://github.com/${GITHUB_REPOSITORY}.git#${INPUT_BRANCH}:${INPUT_FOLDER}
+az acr build -r ${INPUT_REGISTRY} ${DOCKER_BUILD_ARGS} -f ${INPUT_DOCKERFILE} -t ${INPUT_REPOSITORY}${IMAGE_PART}:${INPUT_TAG} https://github.com/${GITHUB_REPOSITORY}.git#${INPUT_BRANCH}:${INPUT_FOLDER}


### PR DESCRIPTION
Added support for using `--build-arg` with Docker builds

Since Github Actions only support string inputs, the format of the argument is a JSON payload.

- build_args: '[{"MY_ARG":"test"},{"NEXT_ARG": "123}]'

which translates to `--build arg MY_ARG="test" --build-arg NEXT_ARG: "123"`